### PR TITLE
[HOTFIX/#30] : 카카오 계정으로 로그인 오류 수정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,6 +10,10 @@ plugins {
 val properties = Properties()
 properties.load(rootProject.file("local.properties").inputStream())
 
+fun String.removeQuotes(): String {
+    return this.replace("\"", "")
+}
+
 android {
     namespace = "com.teamkkumul.kkumul"
     compileSdk = 34
@@ -23,8 +27,10 @@ android {
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
-        buildConfigField("String", "KAKAO_APP_KEY", properties["kakao.app.key"].toString())
-        manifestPlaceholders["kakaoAppkey"] = properties["kakao.app.key"] as String
+        val kakaoAppKey = properties["kakao.app.key"].toString().removeQuotes()
+
+        buildConfigField("String", "KAKAO_APP_KEY", "\"$kakaoAppKey\"")
+        manifestPlaceholders["kakaoAppkey"] = kakaoAppKey
     }
 
     buildTypes {


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요
- 리뷰는 (아직 미정)에 진행됩니다.
- P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #30 

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- [x] 카카오 계정으로 로그인 오류 수정
- [x] "" 제거

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁


## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
이제 카카오 계정도 잘 됩니두~